### PR TITLE
Added date parse to correctly equate events and outreaches

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -93,7 +93,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
           .head()
           .value()
           .updated_at;
-        if (latestEventDate > latestOutreachDate) {
+        if (Date.parse(latestEventDate) > Date.parse(latestOutreachDate)) {
           return 'background-color:#0cc6f4;';
         } else {
           return '';

--- a/app/views/leads/index.html.erb
+++ b/app/views/leads/index.html.erb
@@ -26,7 +26,7 @@
             </thead>
             <tbody>
               <template v-for="lead in leads">
-                <tr v-on:click="showEvents(lead.id)" :key="lead.id" v-bind:style=" rowColor(lead)">
+                <tr v-on:click="showEvents(lead.id)" :key="lead.id" v-bind:style="rowColor(lead)">
                   <td>{{ moment(lead.created_at).format('dddd MMM Do YYYY, h:mm a') }}</td>
                   <td>{{ lead.first_name }}</td>
                   <td>{{ lead.last_name }}</td>


### PR DESCRIPTION
Added Date.parse() function to RowColor function in app.js. This correctly equates the 6 hour difference in the timezones. It should now return the correct color.