### PR TITLE
fixed order gap bug

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -8,7 +8,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
         time_format: "12/25/17",
         url: "https://www.google.com/",
         search: '',
-        reverse: 1,
+        reverse: -1,
         sort: 'recent_event_date',
         page: 1
       };


### PR DESCRIPTION
Hi Jay,
I think I found the issue we discussed the other night.  It looks like when using the paging method to load more results, we mistakenly set the default results to be ordered by ascending rather than descending. 
I think this PR should fix the issue.